### PR TITLE
Update PHP CS Fixer to v2.18

### DIFF
--- a/php-cs-fixer/Dockerfile
+++ b/php-cs-fixer/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="http://github.com/inextensodigital/actions"
 LABEL "homepage"="http://github.com/inextensodigital"
 LABEL "maintainer"="IED <contact@inextenso.digital>"
 
-RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.4/php-cs-fixer.phar -O /usr/local/bin/php-cs-fixer \
+RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.18.0/php-cs-fixer.phar -O /usr/local/bin/php-cs-fixer \
     && chmod a+x /usr/local/bin/php-cs-fixer
 
 ENTRYPOINT ["php-cs-fixer", "fix", "--dry-run", "--diff"]


### PR DESCRIPTION
PHPCS 2.18 are lots of modification since 2.16.4

The major improvement is the complete support for PSR-12 standard https://www.php-fig.org/psr/psr-12/