### PR TITLE
Bump version of php cs fixer to the latest

### DIFF
--- a/php-cs-fixer/Dockerfile
+++ b/php-cs-fixer/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="http://github.com/inextensodigital/actions"
 LABEL "homepage"="http://github.com/inextensodigital"
 LABEL "maintainer"="IED <contact@inextenso.digital>"
 
-RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.1.0/php-cs-fixer.phar -O /usr/local/bin/php-cs-fixer \
+RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.3.2/php-cs-fixer.phar -O /usr/local/bin/php-cs-fixer \
     && chmod a+x /usr/local/bin/php-cs-fixer
 
 ENTRYPOINT ["php-cs-fixer", "fix", "--dry-run", "--diff"]


### PR DESCRIPTION
The diff between versions: https://github.com/FriendsOfPHP/PHP-CS-Fixer/compare/v3.1.0...v3.3.2 and release note page: https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases